### PR TITLE
Add CLI to use in any repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [Unreleased]
+
+## Added
+
+- CLI: Use diffcrypt from command line of any project without requiring ruby integration
+- CLI: `diffcrypt encrypt` Directly encrypt any file and output the contents
+- CLI: `diffcrypt decrypt` Directly decrypt any file and output the contents
+
+
+
 ## [0.2.0] - 2020-06-28
 
 ### Added

--- a/bin/diffcrypt
+++ b/bin/diffcrypt
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'thor'
+
+require_relative '../lib/diffcrypt/cli'
+
+Diffcrypt::CLI.start(ARGV)

--- a/diffcrypt.gemspec
+++ b/diffcrypt.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport', '~> 6.0.0'
+  spec.add_runtime_dependency 'thor', '~> 1.0.1'
 end

--- a/diffcrypt.gemspec
+++ b/diffcrypt.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = 'bin'
+  spec.executables = %w[diffcrypt]
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport', '~> 6.0.0'

--- a/lib/diffcrypt/cli.rb
+++ b/lib/diffcrypt/cli.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative './encryptor'
+require_relative './version'
+
+module Diffcrypt
+  class CLI < Thor
+    desc 'decrypt <path>', 'Decrypt a file'
+    method_option :key, aliases: %i[k], required: true
+    def decrypt(path)
+      contents = File.read(path)
+      puts encryptor.decrypt(contents)
+    end
+
+    desc 'encrypt <path>', 'Encrypt a file'
+    method_option :key, aliases: %i[k], required: true
+    def encrypt(path)
+      contents = File.read(path)
+      puts encryptor.encrypt(contents)
+    end
+
+    desc 'version', 'Show client version'
+    def version
+      say Diffcrypt::VERSION
+    end
+
+    no_commands do
+      def key
+        options[:key]
+      end
+
+      def encryptor
+        @encryptor ||= Encryptor.new(key)
+      end
+    end
+  end
+end

--- a/lib/diffcrypt/cli.rb
+++ b/lib/diffcrypt/cli.rb
@@ -8,6 +8,7 @@ module Diffcrypt
     desc 'decrypt <path>', 'Decrypt a file'
     method_option :key, aliases: %i[k], required: true
     def decrypt(path)
+      ensure_file_exists(path)
       contents = File.read(path)
       puts encryptor.decrypt(contents)
     end
@@ -15,6 +16,7 @@ module Diffcrypt
     desc 'encrypt <path>', 'Encrypt a file'
     method_option :key, aliases: %i[k], required: true
     def encrypt(path)
+      ensure_file_exists(path)
       contents = File.read(path)
       puts encryptor.encrypt(contents)
     end
@@ -31,6 +33,10 @@ module Diffcrypt
 
       def encryptor
         @encryptor ||= Encryptor.new(key)
+      end
+
+      def ensure_file_exists(path)
+        abort('[ERROR] File does not exist') unless File.exist?(path)
       end
     end
   end

--- a/lib/diffcrypt/encryptor.rb
+++ b/lib/diffcrypt/encryptor.rb
@@ -8,6 +8,8 @@ require 'yaml'
 
 require 'active_support/message_encryptor'
 
+require_relative './version'
+
 module Diffcrypt
   class Encryptor
     CIPHER = 'aes-128-gcm'

--- a/test/diffcrypt/cli_test.rb
+++ b/test/diffcrypt/cli_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'thor'
+
+require_relative '../../lib/diffcrypt/cli'
+
+class Diffcrypt::CLITest < Minitest::Test
+  def test_it_extends_thor
+    assert Diffcrypt::CLI < Thor
+  end
+end


### PR DESCRIPTION
This opens up the tool to be used with any repo/project, rather than just rails.

## Usage

```shell
diffcrypt decrypt -k $(cat test/fixtures/master.key) test/fixtures/example.yml.enc > tmp/decrypted.yml
diffcrypt encrypt -k $(cat test/fixtures/master.key) test/fixtures/example.yml > tmp/encrypted.yml
```