### PR TITLE
Release: 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- No longer geneate and store a checksum. Backwards compatible since it wasn't used
+- No longer generate and store a checksum. Backwards compatible since it wasn't used
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [Unreleased]
+## [0.3.2] - 2020-07-20
 
 ### Added
 
 - CLI: `diffcrypt generate-key` command to generate a new key for a cipher
+- Internal: Library now generates and publishes code coverage publically on Code Climate
+
+### Changed
+
+- Only support ruby 2.5+ since 2.4 is no longer maintained
+
+### Removed
+
+- No longer geneate and store a checksum. Backwards compatible since it wasn't used
 
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Since the internal APIs may change dramatically until v1.0, here is a list of th
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.0   | :white_check_mark: |
+| 0.3.x   | :white_check_mark: |
 
 
 

--- a/lib/diffcrypt/version.rb
+++ b/lib/diffcrypt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Diffcrypt
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
### Added

- CLI: `diffcrypt generate-key` command to generate a new key for a cipher
- Internal: Library now generates and publishes code coverage publically on Code Climate

### Changed

- Only support ruby 2.5+ since 2.4 is no longer maintained

### Removed

- No longer generate and store a checksum. Backwards compatible since it wasn't used