### PR TITLE
Release: 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Explicit FileUtils require to avoid potentialy warning logs
+- Explicit FileUtils require to avoid potentially warning logs
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.3.3] - 2020-07-25
+
+### Fixed
+
+- Explicit FileUtils require to avoid potentialy warning logs
+
+
+
 ## [0.3.2] - 2020-07-20
 
 ### Added

--- a/lib/diffcrypt/version.rb
+++ b/lib/diffcrypt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Diffcrypt
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
### Fixed

- Explicit FileUtils require to avoid potentially warning logs
