### PR TITLE
Fix missing cipher on file decryption

### DIFF
--- a/lib/diffcrypt/file.rb
+++ b/lib/diffcrypt/file.rb
@@ -34,10 +34,11 @@ module Diffcrypt
       Encryptor.new(key, cipher: cipher).encrypt(read)
     end
 
+    # TODO: Add a test to verify this does descrypt properly
     def decrypt(key)
       return read unless encrypted?
 
-      Encryptor.new(key).decrypt(read)
+      Encryptor.new(key, cipher: cipher).decrypt(read)
     end
 
     def to_yaml


### PR DESCRIPTION
Currently if a file was encrypted with any cipher other than the default, decryption would fail.