### PR TITLE
Fix undefined instance var AS encryptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ end
 
 ## Converting between ciphers
 
-Sometimes you may want to rotate the cipher used on a file. You cab do this rogramtically using the ruby code above, or you can also chain the CLI commands like so:
+Sometimes you may want to rotate the cipher used on a file. You can do this programmatically using the ruby code above, or you can also chain the CLI commands like so:
 
 ```shell
 diffcrypt decrypt -k $(cat test/fixtures/aes-128-gcm.key) test/fixtures/example.yml.enc > test/fixtures/example.128.yml \

--- a/lib/diffcrypt/rails/encrypted_configuration.rb
+++ b/lib/diffcrypt/rails/encrypted_configuration.rb
@@ -99,7 +99,7 @@ module Diffcrypt
       # @return [String]
       def decrypt(contents)
         if contents.index('---').nil?
-          @active_support_encryptor.decrypt_and_verify contents
+          active_support_encryptor.decrypt_and_verify contents
         else
           encryptor.decrypt contents
         end

--- a/lib/diffcrypt/rails/encrypted_configuration.rb
+++ b/lib/diffcrypt/rails/encrypted_configuration.rb
@@ -108,7 +108,7 @@ module Diffcrypt
       # Rails applications with an existing credentials file, the inbuilt active support encryptor should be used
       # @return [ActiveSupport::MessageEncryptor]
       def active_support_encryptor
-        @active_support_encryptor = ActiveSupport::MessageEncryptor.new(
+        @active_support_encryptor ||= ActiveSupport::MessageEncryptor.new(
           [key].pack('H*'),
           cipher: @diffcrypt_file.cipher,
         )


### PR DESCRIPTION
creating new credentials fails with 
```
0.4.0/lib/diffcrypt/rails/encrypted_configuration.rb:102:in `decrypt': undefined method `decrypt_and_verify' for nil:NilClass (NoMethodError)
```

it seems `decrypt_and_verify` is never called, thus `@decrypt_and_verify` is not populated and hence results in this error.

Not sure if
```ruby
      def active_support_encryptor
        @active_support_encryptor = ActiveSupport::MessageEncryptor.new(
          [key].pack('H*'),
          cipher: @diffcrypt_file.cipher,
        )
      end
```
was intended to memorize the AS Message Encryptor instance, if so, we can drop in `@active_support_encryptor ||= ...`.